### PR TITLE
Update api calls for 2023

### DIFF
--- a/Evac4Bim/Commands/CmdBuildingGroup/CmdBuildingGroup.csproj
+++ b/Evac4Bim/Commands/CmdBuildingGroup/CmdBuildingGroup.csproj
@@ -68,6 +68,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Commands/CmdCreateSchedules/CmdCreateSchedules.csproj
+++ b/Evac4Bim/Commands/CmdCreateSchedules/CmdCreateSchedules.csproj
@@ -55,6 +55,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Commands/CmdEditOccupantProfiles/CmdEditOccupantProfiles.csproj
+++ b/Evac4Bim/Commands/CmdEditOccupantProfiles/CmdEditOccupantProfiles.csproj
@@ -68,6 +68,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Commands/CmdEditParameters/CmdEditParameters.csproj
+++ b/Evac4Bim/Commands/CmdEditParameters/CmdEditParameters.csproj
@@ -55,6 +55,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Commands/CmdEditRoomFunction/CmdEditRoomFunction.csproj
+++ b/Evac4Bim/Commands/CmdEditRoomFunction/CmdEditRoomFunction.csproj
@@ -68,6 +68,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Commands/CmdExportIfc/CmdExportIfc.csproj
+++ b/Evac4Bim/Commands/CmdExportIfc/CmdExportIfc.csproj
@@ -55,6 +55,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Commands/CmdGenerateInputFile/CmdGenerateInputFile.csproj
+++ b/Evac4Bim/Commands/CmdGenerateInputFile/CmdGenerateInputFile.csproj
@@ -55,6 +55,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Commands/CmdIBCCheck/CmdIBCCheck.csproj
+++ b/Evac4Bim/Commands/CmdIBCCheck/CmdIBCCheck.csproj
@@ -55,6 +55,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Commands/CmdImportParameter/CmdImportParameter/CmdImportParameter.csproj
+++ b/Evac4Bim/Commands/CmdImportParameter/CmdImportParameter/CmdImportParameter.csproj
@@ -64,6 +64,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Commands/CmdLaunchResults/CmdLaunchResults.csproj
+++ b/Evac4Bim/Commands/CmdLaunchResults/CmdLaunchResults.csproj
@@ -55,6 +55,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Commands/CmdLoadParameters/CmdLoadParameters/CmdLoadParameters.cs
+++ b/Evac4Bim/Commands/CmdLoadParameters/CmdLoadParameters/CmdLoadParameters.cs
@@ -49,7 +49,7 @@ namespace Evac4Bim
 
             // create a dictionnary to convert category names (retrieved from csv file) into enumerations
             IDictionary<string, BuiltInCategory> BuiltInCategoryDict = new Dictionary<string, BuiltInCategory>();
-            BuiltInCategoryDict.Add("OST_Doors", BuiltInCategory.OST_Doors); //adding a key/value using the Add() method
+            BuiltInCategoryDict.Add("OST_Doors", BuiltInCategory.OST_Doors);
             BuiltInCategoryDict.Add("OST_Rooms", BuiltInCategory.OST_Rooms);
             BuiltInCategoryDict.Add("OST_ProjectInformation", BuiltInCategory.OST_ProjectInformation);
             BuiltInCategoryDict.Add("OST_Levels", BuiltInCategory.OST_Levels);
@@ -59,9 +59,9 @@ namespace Evac4Bim
 
             // create a dictionnary to convert param types (retrieved from csv file) into enumerations
             IDictionary<string, ForgeTypeId> ParameterTypeDict = new Dictionary<string, ForgeTypeId>();
-            ParameterTypeDict.Add("YesNo", SpecTypeId.Boolean.YesNo); //adding a key/value using the Add() method
-            ParameterTypeDict.Add("TEXT", SpecTypeId.String.Text); //adding a key/value using the Add() method
-            ParameterTypeDict.Add("NUMBER", SpecTypeId.Number); //adding a key/value using the Add() method
+            ParameterTypeDict.Add("YesNo", SpecTypeId.Boolean.YesNo);
+            ParameterTypeDict.Add("TEXT", SpecTypeId.String.Text);
+            ParameterTypeDict.Add("NUMBER", SpecTypeId.Number);
             ParameterTypeDict.Add("AREA", SpecTypeId.Area);
             ParameterTypeDict.Add("INTEGER", SpecTypeId.Int.Integer);
             ParameterTypeDict.Add("LENGTH", SpecTypeId.Length);
@@ -69,7 +69,6 @@ namespace Evac4Bim
  
             string paramList = "";
             int paramCount = 0;
-            string msg = "The following parameters were loaded and configured succesfuly :";
 
             // First check if a shared param txt file is already defined in Revit => overwrite it
             // Else, create one (ask user)

--- a/Evac4Bim/Commands/CmdLoadParameters/CmdLoadParameters/CmdLoadParameters.cs
+++ b/Evac4Bim/Commands/CmdLoadParameters/CmdLoadParameters/CmdLoadParameters.cs
@@ -58,14 +58,14 @@ namespace Evac4Bim
   
 
             // create a dictionnary to convert param types (retrieved from csv file) into enumerations
-            IDictionary<string, ParameterType> ParameterTypeDict = new Dictionary<string, ParameterType>();
-            ParameterTypeDict.Add("YesNo", ParameterType.YesNo); //adding a key/value using the Add() method
-            ParameterTypeDict.Add("TEXT", ParameterType.Text); //adding a key/value using the Add() method
-            ParameterTypeDict.Add("NUMBER", ParameterType.Number); //adding a key/value using the Add() method
-            ParameterTypeDict.Add("AREA", ParameterType.Area);
-            ParameterTypeDict.Add("INTEGER", ParameterType.Integer);
-            ParameterTypeDict.Add("LENGTH", ParameterType.Length);
-            ParameterTypeDict.Add("PERIOD", ParameterType.Period);
+            IDictionary<string, ForgeTypeId> ParameterTypeDict = new Dictionary<string, ForgeTypeId>();
+            ParameterTypeDict.Add("YesNo", SpecTypeId.Boolean.YesNo); //adding a key/value using the Add() method
+            ParameterTypeDict.Add("TEXT", SpecTypeId.String.Text); //adding a key/value using the Add() method
+            ParameterTypeDict.Add("NUMBER", SpecTypeId.Number); //adding a key/value using the Add() method
+            ParameterTypeDict.Add("AREA", SpecTypeId.Area);
+            ParameterTypeDict.Add("INTEGER", SpecTypeId.Int.Integer);
+            ParameterTypeDict.Add("LENGTH", SpecTypeId.Length);
+            ParameterTypeDict.Add("PERIOD", SpecTypeId.Period);
  
             string paramList = "";
             int paramCount = 0;
@@ -205,7 +205,7 @@ namespace Evac4Bim
                 // but check if param already exists ! 
 
 
-                if (ContainsParameterName(bindingMap, option.Name, ParameterGroupDict[paramGroup], option.Type))
+                if (ContainsParameterName(bindingMap, option.Name, ParameterGroupDict[paramGroup], option.GetDataType()))
                 {
                     continue;
 
@@ -245,13 +245,13 @@ namespace Evac4Bim
         /// <param name="bindingMap"></param>
         /// <param name="paramName"></param>
         /// <returns></returns>
-        private static bool ContainsParameterName(BindingMap bindingMap, string paramName, BuiltInParameterGroup paramGroup, ParameterType paramType)
+        private static bool ContainsParameterName(BindingMap bindingMap, string paramName, BuiltInParameterGroup paramGroup, ForgeTypeId paramType)
         {
             DefinitionBindingMapIterator it = bindingMap.ForwardIterator();
             it.Reset();
             while (it.MoveNext())
             {
-                if (it.Key.Name == paramName && it.Key.ParameterGroup == paramGroup && it.Key.ParameterType == paramType)
+                if (it.Key.Name == paramName && it.Key.ParameterGroup == paramGroup && it.Key.GetDataType() == paramType)
                 {
                     return true;
                     

--- a/Evac4Bim/Commands/CmdLoadParameters/CmdLoadParameters/CmdLoadParameters.csproj
+++ b/Evac4Bim/Commands/CmdLoadParameters/CmdLoadParameters/CmdLoadParameters.csproj
@@ -55,6 +55,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Commands/CmdMakePaths/CmdMakePaths.csproj
+++ b/Evac4Bim/Commands/CmdMakePaths/CmdMakePaths.csproj
@@ -68,6 +68,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Commands/CmdPlotCharts/CmdPlotCharts/CmdPlotCharts.csproj
+++ b/Evac4Bim/Commands/CmdPlotCharts/CmdPlotCharts/CmdPlotCharts.csproj
@@ -88,6 +88,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Commands/CmdRenameItems/CmdRenameItems/CmdRenameItems.csproj
+++ b/Evac4Bim/Commands/CmdRenameItems/CmdRenameItems/CmdRenameItems.csproj
@@ -55,6 +55,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Commands/CmdResultAnimation/CmdResultAnimation.csproj
+++ b/Evac4Bim/Commands/CmdResultAnimation/CmdResultAnimation.csproj
@@ -75,6 +75,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2021\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/Evac4Bim/Evac4Bim.csproj
+++ b/Evac4Bim/Evac4Bim.csproj
@@ -69,6 +69,10 @@ xcopy "$(TargetDir)\..\..\..\*.png" "C:\ProgramData\Autodesk\Revit\Addins\2021\E
 xcopy "$(TargetPath)" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
 xcopy "$(TargetDir)Newtonsoft.Json.dll" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
 xcopy "$(TargetDir)\Newtonsoft.Json.xml" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\" /F /R /Y /I
-xcopy "$(TargetDir)\..\..\..\*.png" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\icons\" /F /R /Y /I</PostBuildEvent>
+xcopy "$(TargetDir)\..\..\..\*.png" "C:\ProgramData\Autodesk\Revit\Addins\2022\Evac4Bim\icons\" /F /R /Y /I
+xcopy "$(TargetPath)" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)Newtonsoft.Json.dll" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)\Newtonsoft.Json.xml" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\" /F /R /Y /I
+xcopy "$(TargetDir)\..\..\..\*.png" "C:\ProgramData\Autodesk\Revit\Addins\2023\Evac4Bim\icons\" /F /R /Y /I</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Updates the API Calls from the deprecated `ParameterType` to `ForgeTypeId` and adds post-build events for Revit 2023.

Main Source for my choice:
https://thebuildingcoder.typepad.com/blog/2021/04/whats-new-in-the-revit-2022-api.html#4.1.1

And also https://www.revitapidocs.com/2022

I compiled it for Revit 2023 and successfully loaded it in the software. However, I am not yet proficient enough with the plugin to verify that the expected behavior is still the same as it is with the old API calls.
Also, we should think about adding tests verifying that changes don't break our internal logic.